### PR TITLE
Add remote Whisper STT Audacity module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.15)
+project(audacity_remote_whisper LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(mod-remote-whisper MODULE
+    src/RemoteWhisperModule.cpp
+    src/RemoteWhisperCommand.cpp
+    src/RemoteWhisperClient.cpp
+    src/RemoteWhisperJson.cpp
+    src/RemoteWhisperSettings.cpp
+)
+
+target_include_directories(mod-remote-whisper
+    PRIVATE
+        include
+)
+
+target_link_libraries(mod-remote-whisper
+    PRIVATE
+        ${wxWidgets_LIBRARIES}
+        ${CURL_LIBRARIES}
+)
+
+if(TARGET wxWidgets::wxWidgets)
+    target_link_libraries(mod-remote-whisper PRIVATE wxWidgets::wxWidgets)
+endif()
+
+find_package(CURL REQUIRED)
+find_package(wxWidgets REQUIRED COMPONENTS core base net)
+
+if(wxWidgets_FOUND)
+    include(${wxWidgets_USE_FILE})
+endif()
+
+target_compile_definitions(mod-remote-whisper PRIVATE WXINTL_NO_GETTEXT_MACRO)
+
+install(TARGETS mod-remote-whisper
+    LIBRARY DESTINATION "share/audacity/modules"
+    RUNTIME DESTINATION "share/audacity/modules"
+)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# audacity_stt
-a plugin for audacity that makes a request to STT whisper in file mode
+# Remote Whisper Speech-to-Text Module
+
+This repository contains an Audacity module that sends the current audio selection to an external Whisper-compatible speech-to-text (STT) service and renders the transcript as a label track.
+
+## Features
+
+* Configurable STT service URL and language (via **Edit → Preferences → Remote Whisper**).
+* Sends the current project selection (or the entire project if nothing is selected) as a WAV file to the remote STT service using the HTTP API shown below.
+* Creates or refreshes a label track with word-level regions returned by the service.
+
+## Expected STT API
+
+The module expects an HTTP POST endpoint that accepts raw WAV audio with a `filename` and `language` query. Example request:
+
+```bash
+curl -X POST "https://ai1:443/v1/files?filename=sample.wav&language=en" \
+  -H "Content-Type: audio/wav" \
+  --data-binary '@audio.wav'
+```
+
+Example of the JSON response consumed by the plugin:
+
+```json
+{
+  "result": [
+    {
+      "transcript": "Hello world",
+      "words": [
+        { "start": 0.0, "end": 0.5, "text": "Hello" },
+        { "start": 0.5, "end": 1.0, "text": "world" }
+      ]
+    }
+  ]
+}
+```
+
+## Building
+
+```bash
+cmake -S . -B build -DAUDACITY_PATH=/path/to/audacity
+cmake --build build
+```
+
+The resulting `mod-remote-whisper` library should be copied into Audacity's `modules` directory.

--- a/include/RemoteWhisperClient.h
+++ b/include/RemoteWhisperClient.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <wx/filename.h>
+#include <wx/string.h>
+
+struct RemoteWhisperResponse
+{
+    bool ok = false;
+    wxString errorMessage;
+    wxString body;
+};
+
+class RemoteWhisperClient
+{
+public:
+    RemoteWhisperClient(wxString serverUrl, wxString language);
+
+    RemoteWhisperResponse Transcribe(const wxFileName &file) const;
+
+private:
+    wxString mServerUrl;
+    wxString mLanguage;
+};

--- a/include/RemoteWhisperCommand.h
+++ b/include/RemoteWhisperCommand.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <vector>
+#include <wx/filename.h>
+#include <wx/string.h>
+
+class AudacityProject;
+struct RemoteWhisperWord;
+struct RemoteWhisperResult;
+
+class RemoteWhisperCommand
+{
+public:
+    RemoteWhisperCommand();
+    ~RemoteWhisperCommand();
+
+    void Run(AudacityProject &project);
+
+private:
+    bool EnsureProjectHasAudio(AudacityProject &project);
+    bool ExportSelectionToWave(AudacityProject &project, wxFileName &path, double &startTime);
+    bool RequestTranscription(const wxFileName &path, RemoteWhisperResult &result, wxString &error) const;
+    bool CreateOrUpdateLabelTrack(AudacityProject &project, const RemoteWhisperResult &result, double offsetSeconds);
+};
+
+struct RemoteWhisperWord
+{
+    double start = 0.0;
+    double end = 0.0;
+    wxString text;
+};
+
+struct RemoteWhisperUtterance
+{
+    wxString transcript;
+    std::vector<RemoteWhisperWord> words;
+};
+
+struct RemoteWhisperResult
+{
+    std::vector<RemoteWhisperUtterance> utterances;
+};

--- a/include/RemoteWhisperJson.h
+++ b/include/RemoteWhisperJson.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <wx/string.h>
+
+#include "RemoteWhisperCommand.h"
+
+struct RemoteWhisperParseResult
+{
+    bool ok = false;
+    RemoteWhisperResult result;
+    wxString errorMessage;
+};
+
+class RemoteWhisperJsonParser
+{
+public:
+    RemoteWhisperParseResult Parse(const wxString &json) const;
+};

--- a/include/RemoteWhisperModule.h
+++ b/include/RemoteWhisperModule.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ModuleInterface.h"
+#include "ShuttleGui.h"
+
+class wxWindow;
+
+class RemoteWhisperModule final : public ModuleInterface
+{
+public:
+    RemoteWhisperModule();
+    ~RemoteWhisperModule() override;
+
+    wxString GetSymbol() override;
+    wxString GetDescription() override;
+    wxString GetVendor() override;
+    wxString GetVersion() override;
+
+    bool Initialize() override;
+    void Terminate() override;
+    bool RegisterModule(ModuleManagerInterface &moduleManager) override;
+};
+
+ModuleInterface *NewRemoteWhisperModule();

--- a/include/RemoteWhisperSettings.h
+++ b/include/RemoteWhisperSettings.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <functional>
+#include <wx/string.h>
+#include "ShuttleGui.h"
+
+struct RemoteWhisperSettingsData
+{
+    wxString serverUrl;
+    wxString language;
+};
+
+class RemoteWhisperSettings
+{
+public:
+    using Factory = std::function<void(ShuttleGui &)>;
+
+    static RemoteWhisperSettingsData Load();
+    static void Save(const RemoteWhisperSettingsData &data);
+
+    static std::function<void(ShuttleGui &)> CreateFactory();
+};

--- a/src/RemoteWhisperClient.cpp
+++ b/src/RemoteWhisperClient.cpp
@@ -1,0 +1,118 @@
+#include "RemoteWhisperClient.h"
+
+#include <cstdio>
+#include <wx/longlong.h>
+#include <string>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include <curl/curl.h>
+
+namespace
+{
+size_t CurlWriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    auto *str = static_cast<std::string *>(userp);
+    const size_t total = size * nmemb;
+    str->append(static_cast<const char *>(contents), total);
+    return total;
+}
+}
+
+RemoteWhisperClient::RemoteWhisperClient(wxString serverUrl, wxString language)
+    : mServerUrl(std::move(serverUrl)),
+      mLanguage(std::move(language))
+{
+}
+
+RemoteWhisperResponse RemoteWhisperClient::Transcribe(const wxFileName &file) const
+{
+    RemoteWhisperResponse response;
+
+    if (!file.FileExists())
+    {
+        response.errorMessage = wxString::Format(wxT("Audio file %s does not exist."), file.GetFullPath());
+        return response;
+    }
+
+    CURL *curl = curl_easy_init();
+    if (!curl)
+    {
+        response.errorMessage = wxT("Failed to initialize CURL.");
+        return response;
+    }
+
+    std::string buffer;
+
+    const auto baseUrlBuffer = mServerUrl.ToUTF8();
+    const std::string baseUrl(baseUrlBuffer.data());
+    curl_easy_setopt(curl, CURLOPT_URL, baseUrl.c_str());
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+
+    struct curl_slist *headers = nullptr;
+    headers = curl_slist_append(headers, "Content-Type: audio/wav");
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+
+    wxString urlWithQuery = mServerUrl;
+    wxString language = mLanguage.IsEmpty() ? wxT("en") : mLanguage;
+
+    if (!file.GetFullName().IsEmpty())
+    {
+        urlWithQuery += wxString::Format(wxT("?filename=%s&language=%s"),
+                                         file.GetFullName(), language);
+        const auto urlBuffer = urlWithQuery.ToUTF8();
+        const std::string url(urlBuffer.data());
+        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    }
+
+    wxFFile inputFile(file.GetFullPath(), "rb");
+    if (!inputFile.IsOpened())
+    {
+        curl_easy_cleanup(curl);
+        curl_slist_free_all(headers);
+        response.errorMessage = wxString::Format(wxT("Unable to open file %s."), file.GetFullPath());
+        return response;
+    }
+
+    const wxFileOffset length = inputFile.Length();
+    if (length <= 0)
+    {
+        curl_easy_cleanup(curl);
+        curl_slist_free_all(headers);
+        response.errorMessage = wxT("Audio file is empty.");
+        return response;
+    }
+
+    std::string payload;
+    payload.resize(static_cast<size_t>(length));
+    if (inputFile.Read(payload.data(), payload.size()) != payload.size())
+    {
+        curl_easy_cleanup(curl);
+        curl_slist_free_all(headers);
+        response.errorMessage = wxT("Failed to read audio file contents.");
+        return response;
+    }
+
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.size()));
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.data());
+
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);
+
+    auto res = curl_easy_perform(curl);
+
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK)
+    {
+        response.errorMessage = wxString::Format(wxT("Transcription request failed: %s"),
+                                                 wxString::FromUTF8(curl_easy_strerror(res)));
+        return response;
+    }
+
+    response.ok = true;
+    response.body = wxString::FromUTF8(buffer.c_str());
+    return response;
+}

--- a/src/RemoteWhisperCommand.cpp
+++ b/src/RemoteWhisperCommand.cpp
@@ -1,0 +1,260 @@
+#include "RemoteWhisperCommand.h"
+
+#include <cstdint>
+#include <algorithm>
+#include <utility>
+#include <memory>
+#include <wx/dir.h>
+#include <wx/filename.h>
+#include <wx/log.h>
+#include <wx/msgdlg.h>
+#include <wx/ffile.h>
+#include <wx/stdpaths.h>
+#include <wx/utils.h>
+#include <wx/translation.h>
+
+#include "LabelTrack.h"
+#include "Project.h"
+#include "ProjectFileManager.h"
+#include "ProjectSelection.h"
+#include "ProjectWindow.h"
+#include "ViewInfo.h"
+#include "RemoteWhisperClient.h"
+#include "RemoteWhisperJson.h"
+#include "RemoteWhisperSettings.h"
+#include "Track.h"
+#include "TrackList.h"
+#include "WaveTrack.h"
+
+RemoteWhisperCommand::RemoteWhisperCommand() = default;
+RemoteWhisperCommand::~RemoteWhisperCommand() = default;
+
+void RemoteWhisperCommand::Run(AudacityProject &project)
+{
+    if (!EnsureProjectHasAudio(project))
+    {
+        wxMessageBox(_( "No audio tracks were found in the current project." ),
+                     _( "Remote Whisper Transcription" ), wxOK | wxICON_ERROR, project.GetProjectWindow());
+        return;
+    }
+
+    wxFileName audioPath;
+    double offset = 0.0;
+    if (!ExportSelectionToWave(project, audioPath, offset))
+    {
+        wxMessageBox(_( "Unable to prepare audio for transcription." ),
+                     _( "Remote Whisper Transcription" ), wxOK | wxICON_ERROR, project.GetProjectWindow());
+        return;
+    }
+
+    RemoteWhisperResult result;
+    wxString error;
+    if (!RequestTranscription(audioPath, result, error))
+    {
+        wxMessageBox(error,
+                     _( "Remote Whisper Transcription" ), wxOK | wxICON_ERROR, project.GetProjectWindow());
+        return;
+    }
+
+    if (!CreateOrUpdateLabelTrack(project, result, offset))
+    {
+        wxMessageBox(_( "Unable to create label track for transcription results." ),
+                     _( "Remote Whisper Transcription" ), wxOK | wxICON_ERROR, project.GetProjectWindow());
+        return;
+    }
+}
+
+bool RemoteWhisperCommand::EnsureProjectHasAudio(AudacityProject &project)
+{
+    auto &trackList = TrackList::Get(project);
+    bool hasAudio = false;
+    for (auto track : trackList)
+    {
+        if (dynamic_cast<WaveTrack *>(track))
+        {
+            hasAudio = true;
+            break;
+        }
+    }
+    return hasAudio;
+}
+
+bool RemoteWhisperCommand::ExportSelectionToWave(AudacityProject &project, wxFileName &path, double &startTime)
+{
+    auto &selection = ProjectSelection::Get(project);
+    startTime = selection.GetStartTime();
+    double endTime = selection.GetEndTime();
+
+    if (endTime <= startTime)
+    {
+        auto &viewInfo = ViewInfo::Get(project);
+        startTime = viewInfo.selectedRegion.t0();
+        endTime = viewInfo.selectedRegion.t1();
+    }
+
+    if (endTime <= startTime)
+    {
+        auto &trackList = TrackList::Get(project);
+        auto range = trackList.GetTimeBounds();
+        startTime = range.first;
+        endTime = range.second;
+    }
+
+    if (endTime <= startTime)
+        return false;
+
+    auto &trackList = TrackList::Get(project);
+    std::vector<WaveTrack *> waveTracks;
+    for (auto track : trackList)
+    {
+        if (auto wave = dynamic_cast<WaveTrack *>(track))
+            waveTracks.push_back(wave);
+    }
+    if (waveTracks.empty())
+        return false;
+
+    wxFileName tempFile;
+    tempFile.AssignDir(wxStandardPaths::Get().GetTempDir());
+    tempFile.SetName(wxString::Format("audacity-remote-whisper-%ld", wxGetLocalTime()));
+    tempFile.SetExt("wav");
+
+    const auto filePath = tempFile.GetFullPath();
+    wxFFile outputFile(filePath, "wb");
+    if (!outputFile.IsOpened())
+        return false;
+
+    const int sampleRate = static_cast<int>(waveTracks.front()->GetRate());
+    const auto numChannels = waveTracks.size();
+
+    // Write basic WAV header placeholder
+    const uint32_t dataChunkSizePlaceholder = 0;
+    const uint32_t byteRate = sampleRate * numChannels * sizeof(int16_t);
+    const uint16_t blockAlign = numChannels * sizeof(int16_t);
+
+    outputFile.Write("RIFF", 4);
+    outputFile.Write(&dataChunkSizePlaceholder, sizeof(uint32_t));
+    outputFile.Write("WAVE", 4);
+    outputFile.Write("fmt ", 4);
+    const uint32_t fmtChunkSize = 16;
+    outputFile.Write(&fmtChunkSize, sizeof(uint32_t));
+    const uint16_t audioFormat = 1; // PCM
+    outputFile.Write(&audioFormat, sizeof(uint16_t));
+    outputFile.Write(&numChannels, sizeof(uint16_t));
+    outputFile.Write(&sampleRate, sizeof(uint32_t));
+    outputFile.Write(&byteRate, sizeof(uint32_t));
+    outputFile.Write(&blockAlign, sizeof(uint16_t));
+    const uint16_t bitsPerSample = sizeof(int16_t) * 8;
+    outputFile.Write(&bitsPerSample, sizeof(uint16_t));
+    outputFile.Write("data", 4);
+    outputFile.Write(&dataChunkSizePlaceholder, sizeof(uint32_t));
+
+    const size_t bufferFrames = 8192;
+    std::vector<float> buffer(bufferFrames);
+    std::vector<int16_t> interleaved(bufferFrames * numChannels);
+    uint32_t writtenSamples = 0;
+
+    for (size_t channel = 0; channel < numChannels; ++channel)
+    {
+        auto &wave = *waveTracks[channel];
+        auto reader = wave.CreateOptimizedReader(startTime, endTime);
+        double pos = startTime;
+        while (pos < endTime)
+        {
+            auto frames = reader->Read(buffer.data(), bufferFrames, pos, pos + bufferFrames / wave.GetRate());
+            if (frames == 0)
+                break;
+
+            for (size_t i = 0; i < frames; ++i)
+            {
+                const float sample = std::clamp(buffer[i], -1.0f, 1.0f);
+                const auto scaled = static_cast<int16_t>(sample * 32767.0f);
+                interleaved[i * numChannels + channel] = scaled;
+            }
+
+            if (channel == numChannels - 1)
+            {
+                outputFile.Write(interleaved.data(), frames * numChannels * sizeof(int16_t));
+                writtenSamples += frames * numChannels;
+            }
+
+            pos += static_cast<double>(frames) / wave.GetRate();
+        }
+    }
+
+    const uint32_t dataChunkSize = writtenSamples * sizeof(int16_t);
+    const uint32_t riffChunkSize = dataChunkSize + 36;
+    outputFile.Seek(4);
+    outputFile.Write(&riffChunkSize, sizeof(uint32_t));
+    outputFile.Seek(40);
+    outputFile.Write(&dataChunkSize, sizeof(uint32_t));
+    outputFile.Flush();
+
+    path = tempFile;
+    return true;
+}
+
+bool RemoteWhisperCommand::RequestTranscription(const wxFileName &path, RemoteWhisperResult &result, wxString &error) const
+{
+    auto settings = RemoteWhisperSettings::Load();
+    if (settings.serverUrl.empty())
+    {
+        error = _( "Remote Whisper server URL is not configured. Please update the plugin preferences." );
+        return false;
+    }
+
+    RemoteWhisperClient client(settings.serverUrl, settings.language);
+    auto response = client.Transcribe(path);
+    if (!response.ok)
+    {
+        error = response.errorMessage;
+        return false;
+    }
+
+    RemoteWhisperJsonParser parser;
+    auto parseResult = parser.Parse(response.body);
+    if (!parseResult.ok)
+    {
+        error = parseResult.errorMessage;
+        return false;
+    }
+
+    result = std::move(parseResult.result);
+    return true;
+}
+
+bool RemoteWhisperCommand::CreateOrUpdateLabelTrack(AudacityProject &project, const RemoteWhisperResult &result, double offsetSeconds)
+{
+    auto &trackList = TrackList::Get(project);
+    LabelTrack *labelTrack = nullptr;
+
+    for (auto track : trackList)
+    {
+        if (auto label = dynamic_cast<LabelTrack *>(track))
+        {
+            labelTrack = label;
+            break;
+        }
+    }
+
+    if (!labelTrack)
+    {
+        labelTrack = project.NewLabelTrack();
+        if (!labelTrack)
+            return false;
+        trackList.Add(labelTrack);
+    }
+
+    labelTrack->Clear();
+
+    for (const auto &utterance : result.utterances)
+    {
+        for (const auto &word : utterance.words)
+        {
+            const double start = offsetSeconds + word.start;
+            const double end = offsetSeconds + word.end;
+            labelTrack->AddLabel(start, end, word.text);
+        }
+    }
+
+    return true;
+}

--- a/src/RemoteWhisperJson.cpp
+++ b/src/RemoteWhisperJson.cpp
@@ -1,0 +1,218 @@
+#include "RemoteWhisperJson.h"
+
+#include <wx/translation.h>
+#include <cstdlib>
+#include <utility>
+#include <string>
+#include <cctype>
+#include <stack>
+
+namespace
+{
+size_t FindMatching(const std::string &text, size_t start, char open, char close)
+{
+    if (start >= text.size() || text[start] != open)
+        return std::string::npos;
+    std::stack<char> stack;
+    for (size_t i = start; i < text.size(); ++i)
+    {
+        char c = text[i];
+        if (c == open)
+            stack.push(c);
+        else if (c == close)
+        {
+            stack.pop();
+            if (stack.empty())
+                return i;
+        }
+        else if (c == '"')
+        {
+            ++i;
+            while (i < text.size())
+            {
+                char d = text[i];
+                if (d == '\\')
+                {
+                    ++i;
+                    if (i >= text.size())
+                        break;
+                }
+                else if (d == '"')
+                {
+                    break;
+                }
+                ++i;
+            }
+        }
+    }
+    return std::string::npos;
+}
+
+size_t FindStringEnd(const std::string &text, size_t start)
+{
+    for (size_t i = start; i < text.size(); ++i)
+    {
+        if (text[i] == '\\')
+        {
+            ++i;
+            continue;
+        }
+        if (text[i] == '"')
+            return i;
+    }
+    return std::string::npos;
+}
+
+std::string DecodeJsonString(const std::string &value)
+{
+    std::string result;
+    result.reserve(value.size());
+    for (size_t i = 0; i < value.size(); ++i)
+    {
+        char c = value[i];
+        if (c == '\\' && i + 1 < value.size())
+        {
+            char next = value[++i];
+            switch (next)
+            {
+            case '"': result.push_back('"'); break;
+            case '\\': result.push_back('\\'); break;
+            case '/': result.push_back('/'); break;
+            case 'b': result.push_back('\b'); break;
+            case 'f': result.push_back('\f'); break;
+            case 'n': result.push_back('\n'); break;
+            case 'r': result.push_back('\r'); break;
+            case 't': result.push_back('\t'); break;
+            case 'u':
+                if (i + 4 < value.size())
+                {
+                    auto hex = value.substr(i + 1, 4);
+                    unsigned code = std::strtoul(hex.c_str(), nullptr, 16);
+                    if (code <= 0x7F)
+                        result.push_back(static_cast<char>(code));
+                    i += 4;
+                }
+                break;
+            default:
+                result.push_back(next);
+                break;
+            }
+        }
+        else
+        {
+            result.push_back(c);
+        }
+    }
+    return result;
+}
+
+double ParseNumber(const std::string &text)
+{
+    try
+    {
+        return std::stod(text);
+    }
+    catch (...)
+    {
+        return 0.0;
+    }
+}
+}
+
+RemoteWhisperParseResult RemoteWhisperJsonParser::Parse(const wxString &json) const
+{
+    RemoteWhisperParseResult result;
+    std::string text = json.ToStdString();
+    size_t pos = 0;
+
+    while ((pos = text.find("\"words\"", pos)) != std::string::npos)
+    {
+        size_t arrayStart = text.find('[', pos);
+        if (arrayStart == std::string::npos)
+            break;
+        size_t arrayEnd = FindMatching(text, arrayStart, '[', ']');
+        if (arrayEnd == std::string::npos)
+            break;
+
+        RemoteWhisperUtterance utterance;
+
+        size_t transcriptPos = text.rfind("\"transcript\"", pos);
+        if (transcriptPos != std::string::npos)
+        {
+            size_t colon = text.find(':', transcriptPos);
+            if (colon != std::string::npos)
+            {
+                size_t quoteStart = text.find('"', colon);
+                if (quoteStart != std::string::npos)
+                {
+                    size_t quoteEnd = FindStringEnd(text, quoteStart + 1);
+                    if (quoteEnd != std::string::npos)
+                    {
+                        utterance.transcript = wxString::FromUTF8(
+                            DecodeJsonString(text.substr(quoteStart + 1, quoteEnd - quoteStart - 1)).c_str());
+                    }
+                }
+            }
+        }
+
+        auto arrayBody = text.substr(arrayStart + 1, arrayEnd - arrayStart - 1);
+        size_t cursor = 0;
+        while ((cursor = arrayBody.find("\"start\"", cursor)) != std::string::npos)
+        {
+            size_t colon = arrayBody.find(':', cursor);
+            if (colon == std::string::npos)
+                break;
+            size_t comma = arrayBody.find(',', colon);
+            if (comma == std::string::npos)
+                break;
+            auto startValue = arrayBody.substr(colon + 1, comma - colon - 1);
+            RemoteWhisperWord word;
+            word.start = ParseNumber(startValue);
+
+            size_t endPos = arrayBody.find("\"end\"", comma);
+            if (endPos == std::string::npos)
+                break;
+            colon = arrayBody.find(':', endPos);
+            if (colon == std::string::npos)
+                break;
+            comma = arrayBody.find(',', colon);
+            if (comma == std::string::npos)
+                break;
+            auto endValue = arrayBody.substr(colon + 1, comma - colon - 1);
+            word.end = ParseNumber(endValue);
+
+            size_t textPos = arrayBody.find("\"text\"", comma);
+            if (textPos == std::string::npos)
+                break;
+            colon = arrayBody.find(':', textPos);
+            if (colon == std::string::npos)
+                break;
+            size_t quoteStart = arrayBody.find('"', colon);
+            if (quoteStart == std::string::npos)
+                break;
+            size_t quoteEnd = FindStringEnd(arrayBody, quoteStart + 1);
+            if (quoteEnd == std::string::npos)
+                break;
+            word.text = wxString::FromUTF8(
+                DecodeJsonString(arrayBody.substr(quoteStart + 1, quoteEnd - quoteStart - 1)).c_str());
+
+            utterance.words.push_back(std::move(word));
+            cursor = quoteEnd + 1;
+        }
+
+        if (!utterance.words.empty())
+            result.result.utterances.push_back(std::move(utterance));
+
+        pos = arrayEnd + 1;
+    }
+
+    if (result.result.utterances.empty())
+    {
+        result.errorMessage = _( "The transcription response did not contain any words." );
+        result.ok = false;
+        return result;
+    }
+
+    result.ok = true;
+    return result;
+}

--- a/src/RemoteWhisperModule.cpp
+++ b/src/RemoteWhisperModule.cpp
@@ -1,0 +1,71 @@
+#include "RemoteWhisperModule.h"
+
+#include <wx/menu.h>
+#include <wx/msgdlg.h>
+
+#include "Project.h"
+#include <wx/translation.h>
+#include "ModuleManager.h"
+#include "ProjectManager.h"
+#include "RemoteWhisperCommand.h"
+#include "RemoteWhisperSettings.h"
+
+RemoteWhisperModule::RemoteWhisperModule() = default;
+RemoteWhisperModule::~RemoteWhisperModule() = default;
+
+wxString RemoteWhisperModule::GetSymbol()
+{
+    return wxT("remote_whisper_transcription");
+}
+
+wxString RemoteWhisperModule::GetDescription()
+{
+    return _( "Remote Whisper transcription using an external speech-to-text service" );
+}
+
+wxString RemoteWhisperModule::GetVendor()
+{
+    return wxT("OpenAI");
+}
+
+wxString RemoteWhisperModule::GetVersion()
+{
+    return wxT("1.0.0");
+}
+
+bool RemoteWhisperModule::Initialize()
+{
+    return true;
+}
+
+void RemoteWhisperModule::Terminate()
+{
+}
+
+bool RemoteWhisperModule::RegisterModule(ModuleManagerInterface &moduleManager)
+{
+    auto onCommand = [] (AudacityProject &project) {
+        RemoteWhisperCommand command;
+        command.Run(project);
+    };
+
+    moduleManager.RegisterModuleCommand(
+        wxT("Tools"),
+        wxT("remote-whisper-transcription"),
+        _( "Remote Whisper Transcription..." ),
+        onCommand
+    );
+
+    moduleManager.RegisterPreferencesFactory(
+        RemoteWhisperSettings::CreateFactory()
+    );
+
+    return true;
+}
+
+ModuleInterface *NewRemoteWhisperModule()
+{
+    return new RemoteWhisperModule();
+}
+
+DECLARE_MODULE(RemoteWhisperModule);

--- a/src/RemoteWhisperSettings.cpp
+++ b/src/RemoteWhisperSettings.cpp
@@ -1,0 +1,78 @@
+#include "RemoteWhisperSettings.h"
+
+#include <wx/config.h>
+#include <memory>
+#include <wx/translation.h>
+#include "PrefsPanel.h"
+
+#include "ShuttleGui.h"
+
+namespace
+{
+constexpr auto kConfigPath = wxT("RemoteWhisper");
+constexpr auto kServerUrlKey = wxT("ServerUrl");
+constexpr auto kLanguageKey = wxT("Language");
+
+class RemoteWhisperPreferencesPage : public PrefsPanel
+{
+public:
+    explicit RemoteWhisperPreferencesPage(wxWindow *parent)
+        : PrefsPanel(parent, wxID_ANY, _( "Remote Whisper" ))
+    {
+        auto data = RemoteWhisperSettings::Load();
+
+        ShuttleGui S(this, eIsCreating);
+        S.StartStatic(_( "Remote Whisper Service" ));
+        {
+            S.StartTwoColumn();
+            {
+                S.AddPrompt(_( "Service URL:" ));
+                mServerUrl = S.AddTextBox({}, data.serverUrl, 0);
+
+                S.AddPrompt(_( "Language (ISO code):" ));
+                mLanguage = S.AddTextBox({}, data.language, 0);
+            }
+            S.EndTwoColumn();
+        }
+        S.EndStatic();
+    }
+
+    bool Commit() override
+    {
+        RemoteWhisperSettingsData data;
+        data.serverUrl = mServerUrl->GetValue();
+        data.language = mLanguage->GetValue();
+        RemoteWhisperSettings::Save(data);
+        return true;
+    }
+
+private:
+    wxTextCtrl *mServerUrl = nullptr;
+    wxTextCtrl *mLanguage = nullptr;
+};
+}
+
+RemoteWhisperSettingsData RemoteWhisperSettings::Load()
+{
+    wxConfig config(wxT("audacity"));
+    RemoteWhisperSettingsData data;
+    data.serverUrl = config.Read(kConfigPath + wxT("/" ) + kServerUrlKey, wxEmptyString);
+    data.language = config.Read(kConfigPath + wxT("/") + kLanguageKey, wxT("en"));
+    return data;
+}
+
+void RemoteWhisperSettings::Save(const RemoteWhisperSettingsData &data)
+{
+    wxConfig config(wxT("audacity"));
+    config.Write(kConfigPath + wxT("/") + kServerUrlKey, data.serverUrl);
+    config.Write(kConfigPath + wxT("/") + kLanguageKey, data.language);
+}
+
+std::function<void(ShuttleGui &)> RemoteWhisperSettings::CreateFactory()
+{
+    return [](ShuttleGui &S) {
+        auto window = S.GetParent();
+        auto panel = std::make_unique<RemoteWhisperPreferencesPage>(window);
+        S.AddWindow(panel.release());
+    };
+}


### PR DESCRIPTION
## Summary
- add an Audacity module that calls a remote Whisper-compatible STT server and generates word-level labels
- expose preferences for configuring the server URL and language code
- implement JSON parsing, HTTP upload, and audio export helpers used by the transcription command

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_69088575905c8324ba236890b6a10570