### PR TITLE
Add stub Audacity interfaces to build plugin

### DIFF
--- a/include/LabelTrack.h
+++ b/include/LabelTrack.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Track.h"
+#include <vector>
+#include <wx/string.h>
+
+struct LabelEntry
+{
+    double start = 0.0;
+    double end = 0.0;
+    wxString text;
+};
+
+class LabelTrack : public Track
+{
+public:
+    void Clear()
+    {
+        mEntries.clear();
+    }
+
+    void AddLabel(double start, double end, const wxString &text)
+    {
+        mEntries.push_back({start, end, text});
+    }
+
+private:
+    std::vector<LabelEntry> mEntries;
+};

--- a/include/ModuleInterface.h
+++ b/include/ModuleInterface.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <functional>
+#include <wx/string.h>
+
+class AudacityProject;
+class ShuttleGui;
+
+class ModuleManagerInterface;
+
+class ModuleInterface
+{
+public:
+    virtual ~ModuleInterface() = default;
+
+    virtual wxString GetSymbol() { return wxString(); }
+    virtual wxString GetDescription() { return wxString(); }
+    virtual wxString GetVendor() { return wxString(); }
+    virtual wxString GetVersion() { return wxString(); }
+
+    virtual bool Initialize() { return true; }
+    virtual void Terminate() {}
+    virtual bool RegisterModule(ModuleManagerInterface &) { return true; }
+};
+
+using ModuleCommandCallback = std::function<void(AudacityProject &)>;
+using PreferencesFactory = std::function<void(ShuttleGui &)>;
+
+class ModuleManagerInterface
+{
+public:
+    virtual ~ModuleManagerInterface() = default;
+
+    virtual void RegisterModuleCommand(const wxString &, const wxString &, const wxString &, ModuleCommandCallback)
+    {
+    }
+
+    virtual void RegisterPreferencesFactory(PreferencesFactory)
+    {
+    }
+};
+
+#define DECLARE_MODULE(name)

--- a/include/ModuleManager.h
+++ b/include/ModuleManager.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "ModuleInterface.h"

--- a/include/PrefsPanel.h
+++ b/include/PrefsPanel.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <wx/panel.h>
+
+class PrefsPanel : public wxPanel
+{
+public:
+    PrefsPanel(wxWindow *parent, wxWindowID id, const wxString &title)
+        : wxPanel(parent, id)
+    {
+        SetName(title);
+    }
+
+    virtual bool Commit()
+    {
+        return true;
+    }
+};

--- a/include/Project.h
+++ b/include/Project.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <memory>
+
+#include <wx/window.h>
+
+#include "LabelTrack.h"
+#include "TrackList.h"
+#include "WaveTrack.h"
+
+class AudacityProject
+{
+public:
+    AudacityProject()
+    {
+        mTrackList.Add(new WaveTrack());
+    }
+
+    wxWindow *GetProjectWindow() const
+    {
+        return mWindow;
+    }
+
+    void SetProjectWindow(wxWindow *window)
+    {
+        mWindow = window;
+    }
+
+    LabelTrack *NewLabelTrack()
+    {
+        return new LabelTrack();
+    }
+
+    TrackList &GetTrackList()
+    {
+        return mTrackList;
+    }
+
+private:
+    wxWindow *mWindow = nullptr;
+    TrackList mTrackList;
+};
+
+inline TrackList &TrackList::Get(AudacityProject &project)
+{
+    return project.GetTrackList();
+}

--- a/include/ProjectFileManager.h
+++ b/include/ProjectFileManager.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/include/ProjectManager.h
+++ b/include/ProjectManager.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/include/ProjectSelection.h
+++ b/include/ProjectSelection.h
@@ -1,0 +1,16 @@
+#pragma once
+
+class AudacityProject;
+
+class ProjectSelection
+{
+public:
+    static ProjectSelection &Get(AudacityProject &)
+    {
+        static ProjectSelection selection;
+        return selection;
+    }
+
+    double GetStartTime() const { return 0.0; }
+    double GetEndTime() const { return 0.0; }
+};

--- a/include/ProjectWindow.h
+++ b/include/ProjectWindow.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <wx/window.h>
+
+class ProjectWindow : public wxWindow
+{
+public:
+    using wxWindow::wxWindow;
+};

--- a/include/ShuttleGui.h
+++ b/include/ShuttleGui.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <wx/stattext.h>
+#include <wx/string.h>
+#include <wx/textctrl.h>
+#include <wx/window.h>
+
+enum ShuttleMode
+{
+    eIsCreating,
+    eIsUpdating
+};
+
+class ShuttleGui
+{
+public:
+    ShuttleGui(wxWindow *parent, ShuttleMode)
+        : mParent(parent)
+    {
+    }
+
+    wxWindow *GetParent() const
+    {
+        return mParent;
+    }
+
+    void StartStatic(const wxString &)
+    {
+    }
+
+    void EndStatic()
+    {
+    }
+
+    void StartTwoColumn()
+    {
+    }
+
+    void EndTwoColumn()
+    {
+    }
+
+    wxStaticText *AddPrompt(const wxString &prompt)
+    {
+        auto control = std::make_unique<wxStaticText>(mParent, wxID_ANY, prompt);
+        auto result = control.get();
+        mOwnedWindows.push_back(std::move(control));
+        return result;
+    }
+
+    wxTextCtrl *AddTextBox(const wxString &, const wxString &value, long)
+    {
+        auto control = std::make_unique<wxTextCtrl>(mParent, wxID_ANY, value);
+        auto result = control.get();
+        mOwnedWindows.push_back(std::move(control));
+        return result;
+    }
+
+    void AddWindow(wxWindow *window)
+    {
+        mOwnedWindows.emplace_back(window);
+    }
+
+private:
+    wxWindow *mParent;
+    std::vector<std::unique_ptr<wxWindow>> mOwnedWindows;
+};

--- a/include/Track.h
+++ b/include/Track.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class Track
+{
+public:
+    virtual ~Track() = default;
+};

--- a/include/TrackList.h
+++ b/include/TrackList.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Track.h"
+
+class AudacityProject;
+
+class TrackList
+{
+public:
+    using Storage = std::vector<std::unique_ptr<Track>>;
+
+    class Iterator
+    {
+    public:
+        explicit Iterator(Storage::iterator it) : mIt(it) {}
+
+        Iterator &operator++()
+        {
+            ++mIt;
+            return *this;
+        }
+
+        bool operator!=(const Iterator &other) const
+        {
+            return mIt != other.mIt;
+        }
+
+        Track *operator*() const
+        {
+            return mIt->get();
+        }
+
+    private:
+        Storage::iterator mIt;
+    };
+
+    class ConstIterator
+    {
+    public:
+        explicit ConstIterator(Storage::const_iterator it) : mIt(it) {}
+
+        ConstIterator &operator++()
+        {
+            ++mIt;
+            return *this;
+        }
+
+        bool operator!=(const ConstIterator &other) const
+        {
+            return mIt != other.mIt;
+        }
+
+        Track *operator*() const
+        {
+            return mIt->get();
+        }
+
+    private:
+        Storage::const_iterator mIt;
+    };
+
+    Iterator begin() { return Iterator(mTracks.begin()); }
+    Iterator end() { return Iterator(mTracks.end()); }
+    ConstIterator begin() const { return ConstIterator(mTracks.begin()); }
+    ConstIterator end() const { return ConstIterator(mTracks.end()); }
+
+    void Add(Track *track)
+    {
+        mTracks.emplace_back(track);
+    }
+
+    std::pair<double, double> GetTimeBounds() const
+    {
+        return {0.0, 0.0};
+    }
+
+    static TrackList &Get(AudacityProject &project);
+
+private:
+    Storage mTracks;
+};

--- a/include/ViewInfo.h
+++ b/include/ViewInfo.h
@@ -1,0 +1,22 @@
+#pragma once
+
+class AudacityProject;
+
+class ViewInfo
+{
+public:
+    class SelectionRegion
+    {
+    public:
+        double t0() const { return 0.0; }
+        double t1() const { return 0.0; }
+    };
+
+    static ViewInfo &Get(AudacityProject &)
+    {
+        static ViewInfo info;
+        return info;
+    }
+
+    SelectionRegion selectedRegion;
+};

--- a/include/WaveTrack.h
+++ b/include/WaveTrack.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Track.h"
+#include <memory>
+
+class WaveTrackReader
+{
+public:
+    virtual ~WaveTrackReader() = default;
+    virtual size_t Read(float *, size_t, double, double)
+    {
+        return 0;
+    }
+};
+
+class WaveTrack : public Track
+{
+public:
+    double GetRate() const
+    {
+        return 44100.0;
+    }
+
+    std::unique_ptr<WaveTrackReader> CreateOptimizedReader(double, double)
+    {
+        return std::make_unique<WaveTrackReader>();
+    }
+};

--- a/src/RemoteWhisperClient.cpp
+++ b/src/RemoteWhisperClient.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <sstream>
 #include <vector>
+#include <wx/ffile.h>
 
 #include <curl/curl.h>
 

--- a/src/RemoteWhisperCommand.cpp
+++ b/src/RemoteWhisperCommand.cpp
@@ -12,6 +12,7 @@
 #include <wx/stdpaths.h>
 #include <wx/utils.h>
 #include <wx/translation.h>
+#include <wx/intl.h>
 
 #include "LabelTrack.h"
 #include "Project.h"

--- a/src/RemoteWhisperJson.cpp
+++ b/src/RemoteWhisperJson.cpp
@@ -1,6 +1,7 @@
 #include "RemoteWhisperJson.h"
 
 #include <wx/translation.h>
+#include <wx/intl.h>
 #include <cstdlib>
 #include <utility>
 #include <string>

--- a/src/RemoteWhisperModule.cpp
+++ b/src/RemoteWhisperModule.cpp
@@ -2,6 +2,7 @@
 
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
+#include <wx/intl.h>
 
 #include "Project.h"
 #include <wx/translation.h>

--- a/src/RemoteWhisperSettings.cpp
+++ b/src/RemoteWhisperSettings.cpp
@@ -3,6 +3,7 @@
 #include <wx/config.h>
 #include <memory>
 #include <wx/translation.h>
+#include <wx/intl.h>
 #include "PrefsPanel.h"
 
 #include "ShuttleGui.h"


### PR DESCRIPTION
## Summary
- add lightweight stub headers for the Audacity interfaces the plugin depends on so the project can build independently
- include the missing wxWidgets headers needed for translation macros and wxFFile usage

## Testing
- cmake -S . -B build *(fails: missing CURL package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6908d87968c48324913c9f9bb89ff555