### PR TITLE
Fix translation usage in remote whisper module

### DIFF
--- a/src/RemoteWhisperCommand.cpp
+++ b/src/RemoteWhisperCommand.cpp
@@ -34,8 +34,8 @@ void RemoteWhisperCommand::Run(AudacityProject &project)
 {
     if (!EnsureProjectHasAudio(project))
     {
-        wxMessageBox(_( "No audio tracks were found in the current project." ),
-                     _( "Remote Whisper Transcription" ), wxOK | wxICON_ERROR, project.GetProjectWindow());
+        wxMessageBox(wxGetTranslation(wxT("No audio tracks were found in the current project.")),
+                     wxGetTranslation(wxT("Remote Whisper Transcription")), wxOK | wxICON_ERROR, project.GetProjectWindow());
         return;
     }
 
@@ -43,8 +43,8 @@ void RemoteWhisperCommand::Run(AudacityProject &project)
     double offset = 0.0;
     if (!ExportSelectionToWave(project, audioPath, offset))
     {
-        wxMessageBox(_( "Unable to prepare audio for transcription." ),
-                     _( "Remote Whisper Transcription" ), wxOK | wxICON_ERROR, project.GetProjectWindow());
+        wxMessageBox(wxGetTranslation(wxT("Unable to prepare audio for transcription.")),
+                     wxGetTranslation(wxT("Remote Whisper Transcription")), wxOK | wxICON_ERROR, project.GetProjectWindow());
         return;
     }
 
@@ -53,14 +53,14 @@ void RemoteWhisperCommand::Run(AudacityProject &project)
     if (!RequestTranscription(audioPath, result, error))
     {
         wxMessageBox(error,
-                     _( "Remote Whisper Transcription" ), wxOK | wxICON_ERROR, project.GetProjectWindow());
+                     wxGetTranslation(wxT("Remote Whisper Transcription")), wxOK | wxICON_ERROR, project.GetProjectWindow());
         return;
     }
 
     if (!CreateOrUpdateLabelTrack(project, result, offset))
     {
-        wxMessageBox(_( "Unable to create label track for transcription results." ),
-                     _( "Remote Whisper Transcription" ), wxOK | wxICON_ERROR, project.GetProjectWindow());
+        wxMessageBox(wxGetTranslation(wxT("Unable to create label track for transcription results.")),
+                     wxGetTranslation(wxT("Remote Whisper Transcription")), wxOK | wxICON_ERROR, project.GetProjectWindow());
         return;
     }
 }
@@ -199,7 +199,7 @@ bool RemoteWhisperCommand::RequestTranscription(const wxFileName &path, RemoteWh
     auto settings = RemoteWhisperSettings::Load();
     if (settings.serverUrl.empty())
     {
-        error = _( "Remote Whisper server URL is not configured. Please update the plugin preferences." );
+        error = wxGetTranslation(wxT("Remote Whisper server URL is not configured. Please update the plugin preferences."));
         return false;
     }
 

--- a/src/RemoteWhisperJson.cpp
+++ b/src/RemoteWhisperJson.cpp
@@ -209,7 +209,7 @@ RemoteWhisperParseResult RemoteWhisperJsonParser::Parse(const wxString &json) co
 
     if (result.result.utterances.empty())
     {
-        result.errorMessage = _( "The transcription response did not contain any words." );
+        result.errorMessage = wxGetTranslation(wxT("The transcription response did not contain any words."));
         result.ok = false;
         return result;
     }

--- a/src/RemoteWhisperModule.cpp
+++ b/src/RemoteWhisperModule.cpp
@@ -21,7 +21,7 @@ wxString RemoteWhisperModule::GetSymbol()
 
 wxString RemoteWhisperModule::GetDescription()
 {
-    return _( "Remote Whisper transcription using an external speech-to-text service" );
+    return wxGetTranslation(wxT("Remote Whisper transcription using an external speech-to-text service"));
 }
 
 wxString RemoteWhisperModule::GetVendor()
@@ -53,7 +53,7 @@ bool RemoteWhisperModule::RegisterModule(ModuleManagerInterface &moduleManager)
     moduleManager.RegisterModuleCommand(
         wxT("Tools"),
         wxT("remote-whisper-transcription"),
-        _( "Remote Whisper Transcription..." ),
+        wxGetTranslation(wxT("Remote Whisper Transcription...")),
         onCommand
     );
 

--- a/src/RemoteWhisperSettings.cpp
+++ b/src/RemoteWhisperSettings.cpp
@@ -10,27 +10,27 @@
 
 namespace
 {
-constexpr auto kConfigPath = wxT("RemoteWhisper");
-constexpr auto kServerUrlKey = wxT("ServerUrl");
-constexpr auto kLanguageKey = wxT("Language");
+const wxString kConfigPath{wxT("RemoteWhisper")};
+const wxString kServerUrlKey{wxT("ServerUrl")};
+const wxString kLanguageKey{wxT("Language")};
 
 class RemoteWhisperPreferencesPage : public PrefsPanel
 {
 public:
     explicit RemoteWhisperPreferencesPage(wxWindow *parent)
-        : PrefsPanel(parent, wxID_ANY, _( "Remote Whisper" ))
+        : PrefsPanel(parent, wxID_ANY, wxGetTranslation(wxT("Remote Whisper")))
     {
         auto data = RemoteWhisperSettings::Load();
 
         ShuttleGui S(this, eIsCreating);
-        S.StartStatic(_( "Remote Whisper Service" ));
+        S.StartStatic(wxGetTranslation(wxT("Remote Whisper Service")));
         {
             S.StartTwoColumn();
             {
-                S.AddPrompt(_( "Service URL:" ));
+                S.AddPrompt(wxGetTranslation(wxT("Service URL:")));
                 mServerUrl = S.AddTextBox({}, data.serverUrl, 0);
 
-                S.AddPrompt(_( "Language (ISO code):" ));
+                S.AddPrompt(wxGetTranslation(wxT("Language (ISO code):")));
                 mLanguage = S.AddTextBox({}, data.language, 0);
             }
             S.EndTwoColumn();
@@ -57,7 +57,7 @@ RemoteWhisperSettingsData RemoteWhisperSettings::Load()
 {
     wxConfig config(wxT("audacity"));
     RemoteWhisperSettingsData data;
-    data.serverUrl = config.Read(kConfigPath + wxT("/" ) + kServerUrlKey, wxEmptyString);
+    data.serverUrl = config.Read(kConfigPath + wxT("/") + kServerUrlKey, wxEmptyString);
     data.language = config.Read(kConfigPath + wxT("/") + kLanguageKey, wxT("en"));
     return data;
 }


### PR DESCRIPTION
## Summary
- replace uses of the gettext-style `_` macro with `wxGetTranslation` across the remote whisper plugin to avoid missing identifier errors
- update remote whisper settings constants to use `wxString` so configuration keys concatenate correctly

## Testing
- cmake --build build --config Release *(fails: /workspace/audacity_stt/build is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_6908dbaf4a64832492504336e783359e