### PR TITLE
Add notebook wrapper for Remote Whisper preferences

### DIFF
--- a/include/ShuttleGui.h
+++ b/include/ShuttleGui.h
@@ -31,6 +31,14 @@ public:
     {
     }
 
+    void StartNotebookPage(const wxString &)
+    {
+    }
+
+    void EndNotebookPage()
+    {
+    }
+
     void EndStatic()
     {
     }

--- a/src/RemoteWhisperSettings.cpp
+++ b/src/RemoteWhisperSettings.cpp
@@ -23,6 +23,7 @@ public:
         auto data = RemoteWhisperSettings::Load();
 
         ShuttleGui S(this, eIsCreating);
+        S.StartNotebookPage(wxGetTranslation(wxT("Remote Whisper")));
         S.StartStatic(wxGetTranslation(wxT("Remote Whisper Service")));
         {
             S.StartTwoColumn();
@@ -36,6 +37,7 @@ public:
             S.EndTwoColumn();
         }
         S.EndStatic();
+        S.EndNotebookPage();
     }
 
     bool Commit() override


### PR DESCRIPTION
## Summary
- add notebook page helpers to the ShuttleGui stub
- wrap the Remote Whisper settings controls in a dedicated notebook page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6909f9eaba4c8324acba113a52f8b3f6