### PR TITLE
Add dedicated Remote Whisper settings dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains an Audacity module that sends the current audio selecti
 
 ## Features
 
-* Configurable STT service URL and language (via **Edit → Preferences → Remote Whisper**).
+* Configurable STT service URL and language (via **Edit → Preferences → Remote Whisper** or **Tools → Remote Whisper Settings...**).
 * Sends the current project selection (or the entire project if nothing is selected) as a WAV file to the remote STT service using the HTTP API shown below.
 * Creates or refreshes a label track with word-level regions returned by the service.
 

--- a/include/RemoteWhisperSettings.h
+++ b/include/RemoteWhisperSettings.h
@@ -4,6 +4,8 @@
 #include <wx/string.h>
 #include "ShuttleGui.h"
 
+class wxWindow;
+
 struct RemoteWhisperSettingsData
 {
     wxString serverUrl;
@@ -19,4 +21,6 @@ public:
     static void Save(const RemoteWhisperSettingsData &data);
 
     static std::function<void(ShuttleGui &)> CreateFactory();
+
+    static bool ShowDialog(wxWindow *parent);
 };

--- a/src/RemoteWhisperModule.cpp
+++ b/src/RemoteWhisperModule.cpp
@@ -57,6 +57,18 @@ bool RemoteWhisperModule::RegisterModule(ModuleManagerInterface &moduleManager)
         onCommand
     );
 
+    auto onSettings = [](AudacityProject &project) {
+        auto *parent = project.GetProjectWindow();
+        RemoteWhisperSettings::ShowDialog(parent);
+    };
+
+    moduleManager.RegisterModuleCommand(
+        wxT("Tools"),
+        wxT("remote-whisper-settings"),
+        wxGetTranslation(wxT("Remote Whisper Settings...")),
+        onSettings
+    );
+
     moduleManager.RegisterPreferencesFactory(
         RemoteWhisperSettings::CreateFactory()
     );

--- a/src/RemoteWhisperSettings.cpp
+++ b/src/RemoteWhisperSettings.cpp
@@ -4,6 +4,9 @@
 #include <memory>
 #include <wx/translation.h>
 #include <wx/intl.h>
+#include <wx/dialog.h>
+#include <wx/sizer.h>
+#include <wx/button.h>
 #include "PrefsPanel.h"
 
 #include "ShuttleGui.h"
@@ -78,4 +81,26 @@ std::function<void(ShuttleGui &)> RemoteWhisperSettings::CreateFactory()
         auto panel = std::make_unique<RemoteWhisperPreferencesPage>(window);
         S.AddWindow(panel.release());
     };
+}
+
+bool RemoteWhisperSettings::ShowDialog(wxWindow *parent)
+{
+    wxDialog dialog(parent, wxID_ANY, wxGetTranslation(wxT("Remote Whisper Settings")),
+                    wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+
+    auto *panel = new RemoteWhisperPreferencesPage(&dialog);
+
+    auto *sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->Add(panel, 1, wxEXPAND | wxALL, 10);
+
+    auto *buttonSizer = dialog.CreateStdDialogButtonSizer(wxOK | wxCANCEL);
+    if (buttonSizer)
+        sizer->Add(buttonSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    dialog.SetSizerAndFit(sizer);
+
+    if (dialog.ShowModal() == wxID_OK)
+        return panel->Commit();
+
+    return false;
 }


### PR DESCRIPTION
## Summary
- add a reusable dialog helper so the Remote Whisper module exposes its configuration outside the preferences tree
- register a Tools menu command that opens the Remote Whisper settings dialog
- document the alternate access path for the configuration UI

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6909fdf839d08324b001209d31d84863