### PR TITLE
Create Remote Whisper submenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains an Audacity module that sends the current audio selecti
 
 ## Features
 
-* Configurable STT service URL and language (via **Edit → Preferences → Remote Whisper** or **Tools → Remote Whisper Settings...**).
+* Configurable STT service URL and language (via **Edit → Preferences → Remote Whisper** or **Tools → Remote Whisper → Remote Whisper Settings...**).
 * Sends the current project selection (or the entire project if nothing is selected) as a WAV file to the remote STT service using the HTTP API shown below.
 * Creates or refreshes a label track with word-level regions returned by the service.
 

--- a/src/RemoteWhisperModule.cpp
+++ b/src/RemoteWhisperModule.cpp
@@ -50,8 +50,10 @@ bool RemoteWhisperModule::RegisterModule(ModuleManagerInterface &moduleManager)
         command.Run(project);
     };
 
+    const wxString menuPath = wxT("Tools/Remote Whisper");
+
     moduleManager.RegisterModuleCommand(
-        wxT("Tools"),
+        menuPath,
         wxT("remote-whisper-transcription"),
         wxGetTranslation(wxT("Remote Whisper Transcription...")),
         onCommand
@@ -63,7 +65,7 @@ bool RemoteWhisperModule::RegisterModule(ModuleManagerInterface &moduleManager)
     };
 
     moduleManager.RegisterModuleCommand(
-        wxT("Tools"),
+        menuPath,
         wxT("remote-whisper-settings"),
         wxGetTranslation(wxT("Remote Whisper Settings...")),
         onSettings


### PR DESCRIPTION
## Summary
- add a dedicated Tools > Remote Whisper submenu so the transcription and settings commands appear together
- update the README instructions to reference the new submenu structure

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690a12add37883248431181574e131cd