### PR TITLE
Add static linking support for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(audacity_remote_whisper LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Force static linking on Windows
+if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    add_compile_options(/MT$<$<CONFIG:Debug>:d>)
+endif()
+
 # Find required packages
 find_package(CURL REQUIRED)
 find_package(nlohmann_json REQUIRED)


### PR DESCRIPTION
- Force static MSVC runtime (/MT instead of /MD)
- Set CMAKE_MSVC_RUNTIME_LIBRARY to MultiThreaded
- Enables building standalone .exe with no DLL dependencies

To build statically:
1. Install static vcpkg packages: vcpkg install curl:x64-windows-static nlohmann-json:x64-windows-static
2. Use -DVCPKG_TARGET_TRIPLET=x64-windows-static when configuring
3. Result: whisper-helper.exe with no runtime dependencies