### PR TITLE
Fix static linking: Force CURL static library usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     add_compile_options(/MT$<$<CONFIG:Debug>:d>)
+
+    # Force static libraries
+    set(BUILD_SHARED_LIBS OFF)
+    set(CURL_STATICLIB ON)
 endif()
 
 # Find required packages
@@ -29,6 +33,11 @@ target_link_libraries(whisper-helper
         CURL::libcurl
         nlohmann_json::nlohmann_json
 )
+
+# Define CURL_STATICLIB for static linking
+if(MSVC)
+    target_compile_definitions(whisper-helper PRIVATE CURL_STATICLIB)
+endif()
 
 # Installation rules
 install(TARGETS whisper-helper


### PR DESCRIPTION
Changes:
- Set BUILD_SHARED_LIBS=OFF to prefer static libraries
- Set CURL_STATICLIB=ON to tell FindCURL to use static lib
- Add CURL_STATICLIB compile definition to helper target

This ensures CURL is statically linked, eliminating libcurl.dll dependency.

Build command remains:
  cmake -S . -B build -G "Visual Studio 17 2022" -A x64 \
    -DCMAKE_TOOLCHAIN_FILE=path/to/vcpkg.cmake \
    -DVCPKG_TARGET_TRIPLET=x64-windows-static